### PR TITLE
Changed home page name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: UNL UAV
+site_name: Home - UNL UAV
 nav:
   - Home: index.md
   - Teams: teams.md


### PR DESCRIPTION
Website home page name on browser tab now reads "Home - UNL UAV".